### PR TITLE
Fixed dispatcher crash when non-subordinate requested an airspace lock

### DIFF
--- a/SCAM_DispatcherOnly.cs
+++ b/SCAM_DispatcherOnly.cs
@@ -1260,7 +1260,7 @@ public class Dispatcher
 		for (int i = 0; i < stateWrapper.PState.airspaceLockRequests.Count(); ++i) {
 
 			/* Get some information about the applicant. */
-			var sb = subordinates.First(s => s.Id == stateWrapper.PState.airspaceLockRequests[i].id);
+			var sb = subordinates.FirstOrDefault(s => s.Id == stateWrapper.PState.airspaceLockRequests[i].id);
 			if (sb == null) {
 				/* Drop requests from obsolete agents. */
 				Log($"Agent {stateWrapper.PState.airspaceLockRequests[i].id} is no longer a subordinate. Dropping its request for airspace lock.", E.LogLevel.Warning);

--- a/bin/script_dispatcher.cs
+++ b/bin/script_dispatcher.cs
@@ -487,7 +487,8 @@ MinerState.WaitingForDocking:case MinerState.ReturningToShaft:case MinerState.Re
 Report.v)>0&&dist.Length()>50.0)continue;if(dist.Length()>600.0)continue;if(applicant.Echelon<sb.Echelon)continue;if(sb.Report
 .v.Length()<=0.1&&stateWrapper.PState.airspaceLockRequests.Any(s=>s.id==sb.Id))continue;return false;}}}return true;}
 public void GrantAirspaceLocks(){int pref=-1;Subordinate pref_sb=new Subordinate();for(int i=0;i<stateWrapper.PState.
-airspaceLockRequests.Count();++i){var sb=subordinates.First(s=>s.Id==stateWrapper.PState.airspaceLockRequests[i].id);if(sb==null){Log($"Agent {stateWrapper.PState.airspaceLockRequests[i].id} is no longer a subordinate. Dropping its request for airspace lock."
+airspaceLockRequests.Count();++i){var sb=subordinates.FirstOrDefault(s=>s.Id==stateWrapper.PState.airspaceLockRequests[i].id);if(sb==null){
+Log($"Agent {stateWrapper.PState.airspaceLockRequests[i].id} is no longer a subordinate. Dropping its request for airspace lock."
 ,E.LogLevel.Warning);stateWrapper.PState.airspaceLockRequests.RemoveAt(i);--i;continue;}if(!IsLockGranteable(stateWrapper
 .PState.airspaceLockRequests[i].lockName,stateWrapper.PState.airspaceLockRequests[i].id))continue;if(pref<0){pref=i;
 pref_sb=sb;continue;}if(pref_sb.Report.state==MinerState.Docked&&sb.Report.state!=MinerState.Docked){pref=i;pref_sb=sb;continue


### PR DESCRIPTION
The special case was not handled properly, `First()` instead of `FirstOrDefault()`. This lead to an exception, crashing the dispatcher.